### PR TITLE
Do not print deprecation notice if json or plain flag is set

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -25,7 +25,11 @@ require("./libs")(program)
 require("./controllers")(program)
 
 // New Doppler CLI Banner
-console.log(chalk.red("DEPRECATED: Please use the new CLI at https://docs.doppler.com/docs/enclave-installation\n\n"))
+const args = new Set(process.argv)
+
+if(!args.has("--json") && !args.has("--plain")) {
+  console.log(chalk.red("DEPRECATED: Please use the new CLI at https://docs.doppler.com/docs/enclave-installation\n\n"))
+}
 
 // Parse Arguments
 program.parse(process.argv);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dopplerhq/cli",
-  "version": "2.0.62",
+  "version": "2.0.63",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dopplerhq/cli",
-  "version": "2.0.62",
+  "version": "2.0.63",
   "description": "The official Doppler CLI.",
   "main": "cli.js",
   "repository": {


### PR DESCRIPTION
**After Merging**
- `npm publish`
- `npm deprecate @dopplerhq/cli@<3.0.0 "Migrate to the new Doppler CLI by visiting https://docs.doppler.com/docs/enclave-installation"`